### PR TITLE
Fix prettier workflow

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -23,7 +23,7 @@ jobs:
           git config user.name ${{ github.actor }}
           git config user.email ${{ github.actor }}@users.noreply.github.com
           git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} \
-          |  xargs --no-run-if-empty -I {} sh -c "
+          |  xargs --no-run-if-empty -I {} bash -c "
             if test -f {} && [[ {} != react_main/public/* ]]; then
               npx prettier --write {}
             fi


### PR DESCRIPTION
- Use `bash ` instead of `sh ` for prettier workflow (bash scripts support `[[ ]]` commands.
- Hopefully this is the last one :')